### PR TITLE
fix: correct typo in automerge setting in renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,7 +12,7 @@
     enabled: true,
     schedule: ["before 3am on Monday"],
   },
-  automerge: ture,
+  automerge: true,
   platformAutomerge: false,
   ignoreTests: false,
   labels: ["dependencies"],


### PR DESCRIPTION
enable renovate automerge